### PR TITLE
add bucket lifecycle policies

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -28,6 +28,15 @@ Resources:
       LoggingConfiguration:
         DestinationBucketName: !Ref LogBucket
         LogFilePrefix: s3-access-logs/product-bucket/
+      LifecycleConfiguration:
+        Rules:
+          - Status: Enabled
+            Transitions:
+              - StorageClass: INTELLIGENT_TIERING
+                TransitionDate: "2021-01-01T00:00:00.000Z"
+          - Status: Enabled
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
       MetricsConfigurations:
         - Id: EntireBucket
       PublicAccessBlockConfiguration:


### PR DESCRIPTION
`TransitionDate` needs to be quoted, see https://github.com/aws-cloudformation/cfn-python-lint/issues/1881

`AbortIncompleteMultipartUpload` is good practice on any bucket that is the target of multi-part uploads (e.g. any large file transfer), see https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-stop-incomplete-mpu-lifecycle-config

The current advertised SARVIEWS inventory is ~7 TB, which costs ~$160/mo to store in S3 standard.  This data is/will be infrequently accessed (i.e. less than 7 TB will be read per month), so any of the Infrequent Access, One-Zone Infrequent Access, or Intelligent Tiering tiers should produce a cost savings (up to 50% off if the data is *never* accessed).  The cost differences between the three tiers aren't enough to worry about.  Intelligent Tiering is the lowest-risk/variability option of the three.