### PR TITLE
increase memory of harvest_products lambda

### DIFF
--- a/harvest_products/cloudformation.yml
+++ b/harvest_products/cloudformation.yml
@@ -63,7 +63,7 @@ Resources:
           EDL_PASSWORD: !Ref EDLPassword
       Code: src/
       Handler: harvest_products.lambda_handler
-      MemorySize: 128
+      MemorySize: 256
       Role: !GetAtt Role.Arn
       Runtime: python3.8
       Timeout: 900


### PR DESCRIPTION
Runs of the lambda checking on ~200 pending products are a little too close to the 128 MB limit, so I'm bumping the limit to 256 MB.

`Memory Size: 128 MB	Max Memory Used: 120`