### PR TITLE
add iam role to manage events from other AWS accounts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ env:
   CLOUDFORMATION_ROLE_ARN: ${{ secrets.CLOUDFORMATION_ROLE_ARN }}
   EDL_USERNAME: ${{ secrets.EDL_USERNAME }}
   EDL_PASSWORD: ${{ secrets.EDL_PASSWORD }}
+  EVENT_MANAGER_ACCOUNT_IDS: ${{ secrets.EVENT_MANAGER_ACCOUNT_IDS }}
 
 jobs:
 
@@ -68,7 +69,8 @@ jobs:
             --parameter-overrides \
                 EDLUsername="${EDL_USERNAME}" \
                 EDLPassword="${EDL_PASSWORD}" \
-                HyP3URL="${HYP3_URL}"
+                HyP3URL="${HYP3_URL}" \
+                EventManagerAccountIds="${EVENT_MANAGER_ACCOUNT_IDS}"
 
       - name: Get associated PR
         if: github.ref == 'refs/heads/main'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.4](https://github.com/ASFHyP3/hyp3-event-monitoring/compare/v0.0.3...v0.0.4)
+### Added
+- New IAM role that can be assumed by external AWS accounts to manage records in the Events table.
+
 ## [0.0.3](https://github.com/ASFHyP3/hyp3-event-monitoring/compare/v0.0.2...v0.0.3)
 ### Changed
 - Check for new granules is now run every 30 minutes instead of every hour.

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -11,6 +11,9 @@ Parameters:
   EDLPassword:
     Type: String
 
+  EventManagerAccountIds:
+    Type: CommaDelimitedList
+
 Resources:
   LogBucket:
     Type: AWS::S3::Bucket
@@ -129,3 +132,28 @@ Resources:
         ProductTable: !Ref ProductTable
         EDLUsername: !Ref EDLUsername
         EDLPassword: !Ref EDLPassword
+
+  EventManagementRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Action: sts:AssumeRole
+          Principal:
+            AWS: !Ref EventManagerAccountIds
+          Effect: Allow
+      Policies:
+        - PolicyName: policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:Scan
+                  - dynamodb:Query
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:DeleteItem
+                Resource: !Sub "${EventTable.Arn}*"


### PR DESCRIPTION
This provisions an IAM role with [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) access to the Event table that can be assumed by other AWS accounts, as provided in a new `EventManagerAccoutIds` cloudformation parameter.

`EVENT_MANAGER_ACCOUNT_IDS` has been added as a repository secret.  Only includes the student account at this time.

Resources in the external account will need to assume this role via STS prior to interacting with the Event table.  Those resources will need `sts:AssumeRole` permissions in that account's IAM.  For an example of assuming a role using boto3, see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-api.html

As written, this grants access for *any* resources within the external account to assume the role.  We could be more strict, say only grant access to a specific role/user/resource within the external account, but I think that's overkill at this time.