### PR TITLE
update to hyp3_sdk v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.5](https://github.com/ASFHyP3/hyp3-event-monitoring/compare/v0.0.4...v0.0.5)
+### Changed
+- Upgraded to hyp3_sdk [v0.6.0](https://github.com/ASFHyP3/hyp3-sdk/blob/develop/CHANGELOG.md#060) from v0.5.0
+
 ## [0.0.4](https://github.com/ASFHyP3/hyp3-event-monitoring/compare/v0.0.3...v0.0.4)
 ### Added
 - New IAM role that can be assumed by external AWS accounts to manage records in the Events table.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.0.5](https://github.com/ASFHyP3/hyp3-event-monitoring/compare/v0.0.4...v0.0.5)
 ### Changed
+- Improved handling of transient server errors (retryable) vs invalid granule errors (not retryable) in `find_new`
 - Upgraded to hyp3_sdk [v0.6.0](https://github.com/ASFHyP3/hyp3-sdk/blob/develop/CHANGELOG.md#060) from v0.5.0
 
 ## [0.0.4](https://github.com/ASFHyP3/hyp3-event-monitoring/compare/v0.0.3...v0.0.4)

--- a/find_new/requirements.txt
+++ b/find_new/requirements.txt
@@ -1,4 +1,4 @@
-hyp3-sdk>=0.5.0
+hyp3-sdk>=0.6.0
 python-dateutil
 requests
 ./database

--- a/find_new/src/find_new.py
+++ b/find_new/src/find_new.py
@@ -85,6 +85,10 @@ def submit_jobs_for_granule(hyp3, event_id, granule):
         neighbors = asf_search.get_nearest_neighbors(granule['granuleName'])
     except ASFSearchError:
         raise GranuleError()
+    except requests.HTTPError as e:
+        print(e)
+        print(f'Server error finding neighbors for {granule}, skipping...')
+        return
 
     for neighbor in neighbors:
         insar_job = hyp3.prepare_insar_job(granule['granuleName'], neighbor['granuleName'], include_look_vectors=True)
@@ -95,6 +99,10 @@ def submit_jobs_for_granule(hyp3, event_id, granule):
         submitted_jobs = hyp3.submit_prepared_jobs(prepared_jobs)
     except HyP3Error:
         raise GranuleError()
+    except requests.HTTPError as e:
+        print(e)
+        print(f'Server error submitting {granule} to HyP3, skipping...')
+        return
 
     for job, granule_list in zip(submitted_jobs, granule_lists):
         product = format_product(job, event_id, granule_list)

--- a/find_new/src/find_new.py
+++ b/find_new/src/find_new.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 import requests
 from dateutil import parser
 from hyp3_sdk import HyP3, asf_search
-from hyp3_sdk.exceptions import HyP3Error
+from hyp3_sdk.exceptions import ASFSearchError, HyP3Error
 
 from database import database
 
@@ -83,13 +83,8 @@ def submit_jobs_for_granule(hyp3, event_id, granule):
 
     try:
         neighbors = asf_search.get_nearest_neighbors(granule['granuleName'])
-    except requests.HTTPError as e:
-        if e.response.status_code in range(400, 500):
-            raise GranuleError()
-        if e.response.status_code >= 500:
-            print(e)
-            print(f'unable to find neighbors for {granule["granuleName"]} skipping...')
-            return
+    except ASFSearchError:
+        raise GranuleError()
 
     for neighbor in neighbors:
         insar_job = hyp3.prepare_insar_job(granule['granuleName'], neighbor['granuleName'], include_look_vectors=True)

--- a/harvest_products/requirements.txt
+++ b/harvest_products/requirements.txt
@@ -1,3 +1,3 @@
-hyp3-sdk>=0.5.0
+hyp3-sdk>=0.6.0
 requests
 ./database

--- a/tests/test_find_new.py
+++ b/tests/test_find_new.py
@@ -9,6 +9,7 @@ from hyp3_sdk import HyP3
 from hyp3_sdk.exceptions import ASFSearchError, HyP3Error
 from hyp3_sdk.util import AUTH_URL
 from mock import patch
+from requests.exceptions import HTTPError
 
 import find_new
 
@@ -299,6 +300,11 @@ def test_submit_jobs_for_granule_submit_error(tables):
                 find_new.submit_jobs_for_granule(hyp3, event_id, granule)
                 assert type(e.__context__) == HyP3Error
 
+    with patch('hyp3_sdk.asf_search.get_nearest_neighbors', lambda x: []):
+        with patch('hyp3_sdk.HyP3.submit_prepared_jobs', side_effect=HTTPError):
+            find_new.submit_jobs_for_granule(hyp3, event_id, granule)
+    assert tables.product_table.scan()['Items'] == []
+
 
 @responses.activate
 def test_submit_jobs_for_granule_neighbor_error(tables):
@@ -318,6 +324,10 @@ def test_submit_jobs_for_granule_neighbor_error(tables):
         with pytest.raises(find_new.GranuleError) as e:
             find_new.submit_jobs_for_granule(hyp3, event_id, granule)
             assert type(e.__context__) == ASFSearchError
+
+    with patch('hyp3_sdk.asf_search.get_nearest_neighbors', side_effect=HTTPError):
+        find_new.submit_jobs_for_granule(hyp3, event_id, granule)
+    assert tables.product_table.scan()['Items'] == []
 
 
 @responses.activate

--- a/tests/test_find_new.py
+++ b/tests/test_find_new.py
@@ -296,7 +296,7 @@ def test_submit_jobs_for_granule_submit_error(tables):
 
     with patch('hyp3_sdk.asf_search.get_nearest_neighbors', lambda x: []):
         with patch('hyp3_sdk.HyP3.submit_prepared_jobs', side_effect=HyP3Error):
-            with pytest.raises(find_new.GranuleError)as e:
+            with pytest.raises(find_new.GranuleError) as e:
                 find_new.submit_jobs_for_granule(hyp3, event_id, granule)
                 assert type(e.__context__) == HyP3Error
 

--- a/tests/test_find_new.py
+++ b/tests/test_find_new.py
@@ -296,9 +296,8 @@ def test_submit_jobs_for_granule_submit_error(tables):
 
     with patch('hyp3_sdk.asf_search.get_nearest_neighbors', lambda x: []):
         with patch('hyp3_sdk.HyP3.submit_prepared_jobs', side_effect=HyP3Error):
-            with pytest.raises(find_new.GranuleError) as e:
+            with pytest.raises(find_new.GranuleError):
                 find_new.submit_jobs_for_granule(hyp3, event_id, granule)
-                assert type(e.__context__) == HyP3Error
 
     with patch('hyp3_sdk.asf_search.get_nearest_neighbors', lambda x: []):
         with patch('hyp3_sdk.HyP3.submit_prepared_jobs', side_effect=HTTPError):
@@ -321,9 +320,8 @@ def test_submit_jobs_for_granule_neighbor_error(tables):
     hyp3 = HyP3(environ['HYP3_URL'], username=environ['EDL_USERNAME'], password=environ['EDL_PASSWORD'])
 
     with patch('hyp3_sdk.asf_search.get_nearest_neighbors', side_effect=ASFSearchError):
-        with pytest.raises(find_new.GranuleError) as e:
+        with pytest.raises(find_new.GranuleError):
             find_new.submit_jobs_for_granule(hyp3, event_id, granule)
-            assert type(e.__context__) == ASFSearchError
 
     with patch('hyp3_sdk.asf_search.get_nearest_neighbors', side_effect=HTTPError):
         find_new.submit_jobs_for_granule(hyp3, event_id, granule)


### PR DESCRIPTION
Neighbor searches will no longer result in errors from missing state vectors in CMR, eliminating the need for special error handling to retry those granules later.

Granules for jobs rejected by the HyP3 API with a 4xx response (e.g. no dem coverage) will still be logged as failed.

Granules for which neighbor searches are rejected by the Search API with a 4xx response will now be logged as failed.  I can't think of any granules that would trigger this behavior.

5xx responses from either the HyP3 API or the Search API will be logged, processing will be skipped for that particular granule, and processing will continue with subsequent granules.  The offending granule will be retried as normal in the next scheduled run of `find_new`.