### PR TITLE
grant tagging permissions for harvest_products lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.0.8](https://github.com/ASFHyP3/hyp3-event-monitoring/compare/v0.0.7...v0.0.8)
+### Changed
+- Granted additional IAM permissions to the `harvest_products` Lambda function to support transfers of data products
+  smaller than 8 MB.
+
 ## [0.0.7](https://github.com/ASFHyP3/hyp3-event-monitoring/compare/v0.0.6...v0.0.7)
 ### Changed
 - Upgraded to hyp3_sdk [v1.3.2](https://github.com/ASFHyP3/hyp3-sdk/blob/develop/CHANGELOG.md#132) from v1.1.0

--- a/harvest_products/cloudformation.yml
+++ b/harvest_products/cloudformation.yml
@@ -45,10 +45,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - s3:GetObject
+                  - s3:GetObjectTagging
                 Resource: "arn:aws:s3:::*/*"
               - Effect: Allow
                 Action:
                   - s3:PutObject
+                  - s3:PutObjectTagging
                 Resource: !Sub "arn:aws:s3:::${ProductBucket}/*"
 
   Lambda:


### PR DESCRIPTION
I created an event in test that should generate an offending product:
https://il7d9ctd73.execute-api.us-west-2.amazonaws.com/events/fc66301c-b343-4927-900f-76394fe165b8

Once I confirm that encounters the error, I'll merge this PR and confirm the issue resolves itself.