### PR TITLE
Fix neighbor fetching in find_new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.10]
+### Fixed
+- Replaced deprecated `hyp3_sdk.asf_search.get_nearest_neighbors` function with `find_new.get_neighbors`.
+
 ## [0.0.9]
 ### Security
 - Set `NoEcho` for EDL password in CloudFormation stacks.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The HyP3 Event Monitoring source contains test files in `tests/`. To run them yo
 
 - Add components to python path
 ```sh
-export PYTHONPATH="${PYTHONPATH}:`pwd`find_new/src:`pwd`api/src:`pwd`harvest_products/src"
+export PYTHONPATH="${PYTHONPATH}:`pwd`/find_new/src:`pwd`/api/src:`pwd`/harvest_products/src"
 ```
 - Setup environment variables
 ```sh
@@ -97,7 +97,7 @@ export $(cat tests/cfg.env | xargs)
 ```
 - Install test requirements
 ```sh
-pip install -r apps/api/requirements-all.txt
+pip install -r requirements-all.txt
 ```
 
 - Run tests

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The HyP3 Event Monitoring source contains test files in `tests/`. To run them yo
 
 - Add components to python path
 ```sh
-export PYTHONPATH="${PYTHONPATH}:`pwd`/find_new/src:`pwd`/api/src:`pwd`/harvest_products/src"
+export PYTHONPATH="${PYTHONPATH}:${PWD}/find_new/src:${PWD}/api/src:${PWD}/harvest_products/src"
 ```
 - Setup environment variables
 ```sh

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ export $(cat tests/cfg.env | xargs)
 ```
 - Install test requirements
 ```sh
-pip install -r requirements-all.txt
+python -m pip install -r requirements-all.txt
 ```
 
 - Run tests

--- a/find_new/requirements.txt
+++ b/find_new/requirements.txt
@@ -1,3 +1,4 @@
+asf-search==3.0.6
 hyp3-sdk>=1.3.2
 python-dateutil
 requests

--- a/find_new/src/find_new.py
+++ b/find_new/src/find_new.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from os import environ
+from typing import List
 from uuid import uuid4
 
 import asf_search
@@ -9,7 +10,6 @@ from hyp3_sdk import HyP3
 from hyp3_sdk.exceptions import HyP3Error, ServerError
 
 from database import database
-from typing import List
 
 SEARCH_URL = 'https://api.daac.asf.alaska.edu/services/search/param'
 

--- a/find_new/src/find_new.py
+++ b/find_new/src/find_new.py
@@ -9,6 +9,7 @@ from hyp3_sdk import HyP3
 from hyp3_sdk.exceptions import HyP3Error, ServerError
 
 from database import database
+from typing import List
 
 SEARCH_URL = 'https://api.daac.asf.alaska.edu/services/search/param'
 
@@ -73,7 +74,7 @@ def add_invalid_product_record(event_id, granule, message):
     database.put_product(product)
 
 
-def get_neighbors(granule_name: str, max_neighbors: int = 2) -> list[dict]:
+def get_neighbors(granule_name: str, max_neighbors: int = 2) -> List[dict]:
     results = asf_search.product_search([granule_name])
     assert len(results) == 1
     granule: asf_search.ASFProduct = results[0]

--- a/tests/test_find_new.py
+++ b/tests/test_find_new.py
@@ -3,11 +3,12 @@ from os import environ
 from unittest.mock import patch
 from uuid import uuid4
 
+import asf_search
 import pytest
 import responses
 from dateutil import parser
 from hyp3_sdk import HyP3
-from hyp3_sdk.exceptions import ASFSearchError, HyP3Error, ServerError
+from hyp3_sdk.exceptions import HyP3Error, ServerError
 from hyp3_sdk.util import AUTH_URL
 
 import find_new
@@ -318,13 +319,11 @@ def test_submit_jobs_for_granule_neighbor_error(tables):
     responses.add(responses.GET, AUTH_URL)
     hyp3 = HyP3(environ['HYP3_URL'], username=environ['EDL_USERNAME'], password=environ['EDL_PASSWORD'])
 
-    # TODO preserve exception behavior?
-    with patch('hyp3_sdk.asf_search.get_nearest_neighbors', side_effect=ASFSearchError):
+    with patch('find_new.get_neighbors', side_effect=asf_search.ASFSearch4xxError):
         with pytest.raises(find_new.GranuleError):
             find_new.submit_jobs_for_granule(hyp3, event_id, granule)
 
-    # TODO preserve exception behavior?
-    with patch('hyp3_sdk.asf_search.get_nearest_neighbors', side_effect=ServerError):
+    with patch('find_new.get_neighbors', side_effect=asf_search.ASFSearchError):
         find_new.submit_jobs_for_granule(hyp3, event_id, granule)
     assert tables.product_table.scan()['Items'] == []
 


### PR DESCRIPTION
The important function is [get_neighbors](https://github.com/ASFHyP3/hyp3-event-monitoring/blob/6507698314c55e110ede9d264eaeb6924e5230f3/find_new/src/find_new.py#L76). The two extra searches (one at the beginning to convert granule name to an `asf_search.ASFProduct` object and one at the end to convert the neighbors to JSON) keep the function's interface consistent with the old `hyp3_sdk.asf_search.get_nearest_neighbors`, saving me from a bunch of additional refactoring. I'll acknowledge it's somewhat ugly, so let me know if there's a better way to keep the interface consistent.

~The remaining TODO: should we try to preserve the exception behavior found [here](https://github.com/ASFHyP3/hyp3-event-monitoring/blob/6507698314c55e110ede9d264eaeb6924e5230f3/find_new/src/find_new.py#L104)? The new `get_neighbors` function does not raise any exceptions itself, and I'm not sure what exceptions may be raised by the three searches that it calls, so I just wanted to check how much we care about preserving the error handling behavior before I dig into it further.~